### PR TITLE
bump chartist peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack-merge": "^0.14.1"
   },
   "peerDependencies": {
-    "chartist": "^0.10.1",
+    "chartist": "^0.11.0",
     "vue": "^2.0.0"
   }
 }


### PR DESCRIPTION
Judging from https://github.com/gionkunz/chartist-js/blob/develop/CHANGELOG.md, it doesn't appear that there were any breaking changes in this upgrade that would affect v-chartist.  That said, some regression testing wouldn't hurt.

fixes #8 